### PR TITLE
Parse large integers as strings to avoid precision loss

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,10 +7,11 @@ let clientSecret;
 let oauthUrl;
 let apiUrl;
 let timeout;
+let jsonParse = JSON.parse;
 
 function parse(body) {
   try {
-    return JSON.parse(body);
+    return jsonParse(body);
   } catch (e) {
     console.error(e);
     return {};
@@ -59,7 +60,7 @@ function apiRequest(method, resource, payload, authParams, callback) {
           }
         );
       } else {
-        callback(null, body ? JSON.parse(body) : {});
+        callback(null, body ? jsonParse(body) : {});
       }
     });
   });
@@ -76,6 +77,9 @@ module.exports = (config) => {
   oauthUrl = config.oauthUrl;
   apiUrl = config.apiUrl;
   timeout = config.timeout;
+  if (config.bigIntsToStrings) {
+    jsonParse = require('json-bigint')({'storeAsString': true}).parse;
+  }
   return {
     request: apiRequest
   };

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/classy-org/classy-api-client#readme",
   "dependencies": {
+    "json-bigint": "^0.3.0",
     "oauth": "^0.9.15",
     "request": "^2.83.0"
   },


### PR DESCRIPTION
If a particular option is passed in when the API client is created, parse numbers as strings.  If numeric IDs reach a certain size (around 16 digits) the act of parsing them in Javascript will truncate them, since they will be cast to floating point.